### PR TITLE
feat(classifiers): include category_titles defaults for UI labels

### DIFF
--- a/configs/classifiers.yaml
+++ b/configs/classifiers.yaml
@@ -1,5 +1,12 @@
 # Voyage email category classifiers
 # Override path with VOYAGE_CLASSIFIERS_PATH env var
+category_titles:
+  flight: "Flights ✈️"
+  hotel: "Hotels 🏨"
+  cruise: "Cruises 🚢"
+  car_rental: "Car Rental 🚗"
+  activity: "Activities 🎟️"
+  other: "Other 📧"
 categories:
   flight:
     domains:

--- a/docs/docs.go
+++ b/docs/docs.go
@@ -678,6 +678,12 @@ const docTemplate = `{
                     "additionalProperties": {
                         "$ref": "#/definitions/classifier.CategoryRule"
                     }
+                },
+                "category_titles": {
+                    "type": "object",
+                    "additionalProperties": {
+                        "type": "string"
+                    }
                 }
             }
         },

--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -672,6 +672,12 @@
                     "additionalProperties": {
                         "$ref": "#/definitions/classifier.CategoryRule"
                     }
+                },
+                "category_titles": {
+                    "type": "object",
+                    "additionalProperties": {
+                        "type": "string"
+                    }
                 }
             }
         },

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -17,6 +17,10 @@ definitions:
         additionalProperties:
           $ref: '#/definitions/classifier.CategoryRule'
         type: object
+      category_titles:
+        additionalProperties:
+          type: string
+        type: object
     type: object
   handlers.TripEmailItem:
     description: An email associated with a trip

--- a/internal/classifier/category.go
+++ b/internal/classifier/category.go
@@ -31,12 +31,25 @@ type CategoryRule struct {
 
 // ClassifiersConfig defines all classifier categories and their matching rules.
 type ClassifiersConfig struct {
-	Categories map[string]CategoryRule `json:"categories" yaml:"categories"`
+	Categories     map[string]CategoryRule `json:"categories" yaml:"categories"`
+	CategoryTitles map[string]string       `json:"category_titles,omitempty" yaml:"category_titles,omitempty"`
 }
 
 var categoryPriority = []string{"cruise", "car_rental", "hotel", "activity", "flight"}
 
+func defaultCategoryTitles() map[string]string {
+	return map[string]string{
+		"flight":     "Flights ✈️",
+		"hotel":      "Hotels 🏨",
+		"car_rental": "Car Rental 🚗",
+		"cruise":     "Cruises 🚢",
+		"activity":   "Activities 🎟️",
+		"other":      "Other 📧",
+	}
+}
+
 var defaultConfig = ClassifiersConfig{
+	CategoryTitles: defaultCategoryTitles(),
 	Categories: map[string]CategoryRule{
 		"flight": {
 			Domains:         []string{"delta.com", "united.com", "aa.com", "southwest.com", "alaskaair.com", "spirit.com", "jetblue.com", "frontier.com"},
@@ -97,7 +110,10 @@ func resolveConfigPath() string {
 }
 
 func cloneConfig(cfg ClassifiersConfig) ClassifiersConfig {
-	out := ClassifiersConfig{Categories: make(map[string]CategoryRule, len(cfg.Categories))}
+	out := ClassifiersConfig{
+		Categories:     make(map[string]CategoryRule, len(cfg.Categories)),
+		CategoryTitles: make(map[string]string, len(cfg.CategoryTitles)),
+	}
 	for k, v := range cfg.Categories {
 		rule := CategoryRule{
 			Domains:         append([]string(nil), v.Domains...),
@@ -105,11 +121,17 @@ func cloneConfig(cfg ClassifiersConfig) ClassifiersConfig {
 		}
 		out.Categories[k] = rule
 	}
+	for k, v := range cfg.CategoryTitles {
+		out.CategoryTitles[k] = v
+	}
 	return out
 }
 
 func normalizeConfig(cfg ClassifiersConfig) ClassifiersConfig {
-	out := ClassifiersConfig{Categories: make(map[string]CategoryRule, len(cfg.Categories))}
+	out := ClassifiersConfig{
+		Categories:     make(map[string]CategoryRule, len(cfg.Categories)),
+		CategoryTitles: make(map[string]string),
+	}
 	for category, rule := range cfg.Categories {
 		name := strings.TrimSpace(strings.ToLower(category))
 		if name == "" {
@@ -145,6 +167,21 @@ func normalizeConfig(cfg ClassifiersConfig) ClassifiersConfig {
 
 		out.Categories[name] = normRule
 	}
+
+	defaultTitles := defaultCategoryTitles()
+	for key := range out.Categories {
+		if title, ok := cfg.CategoryTitles[key]; ok {
+			t := strings.TrimSpace(title)
+			if t != "" {
+				out.CategoryTitles[key] = t
+				continue
+			}
+		}
+		if defaultTitle, ok := defaultTitles[key]; ok {
+			out.CategoryTitles[key] = defaultTitle
+		}
+	}
+
 	return out
 }
 


### PR DESCRIPTION
## Summary
- add optional  to classifier config
- provide emoji-friendly defaults (Flights ✈️, Hotels 🏨, etc.)
- normalize/persist titles alongside categories
- update default  with 

## Why
Frontend filter pills/settings can now be driven directly from backend classifier config without hardcoded labels, while still preserving friendly notmuch-style labels.

## Notes
- existing configs without  continue to work; defaults are filled automatically for known categories.
